### PR TITLE
Fix sorting stackable equippables.

### DIFF
--- a/modmain.lua
+++ b/modmain.lua
@@ -197,15 +197,15 @@ local function getNextAvailableInventorySlot(player, item, bagPreference)
 		end
 	end
 
-	-- Cconvert the response of GetNextAvailableSlot() into the appropriate object.
+	-- If we got itemslots, return the original inventory
+	-- equipslots are handled in the calling code!
 	if slot then
-		if container == inventory.equipslots or container == inventory.itemslots then
+		if container == inventory.itemslots then
 			container = inventory
 		end
 
 		-- backpack is handled by default.
 	end
-
 	return slot, container
 end
 
@@ -342,7 +342,22 @@ local function sortInventory(player, maxLights, backpackCategory)
 
 			-- Put the item in its sorted slot/container.
 			local slot, container = getNextAvailableInventorySlot(player, itemObj, bagPreference)
-			container:GiveItem(itemObj, slot, nil)
+			if slot ~= nil and container == inventory.equipslots then
+				-- You can't GiveItem to equipslots. So manually combine the itemObj with the equipped stack.
+				local eitem = inventory:GetEquippedItem(slot)
+				-- Combine the sorted itemstack with the equipped stack. Remainder is returned to itemObj.
+				itemObj = (eitem.components.stackable ~= nil) and eitem.components.stackable:Put(itemObj) or itemObj
+				if itemObj ~= nil and itemObj:IsValid() then
+					-- Giving remainder into inventory.
+					local slot, container = getNextAvailableInventorySlot(player, itemObj, bagPreference)
+					container:GiveItem(itemObj, slot, nil)
+				else
+					-- Should we do something with itemObj?
+					print "The sorted item was consumed by the equipslot"
+				end
+			else
+				container:GiveItem(itemObj, slot, nil)
+			end
 		end
 	end
 


### PR DESCRIPTION
Hi, this should fix the issue with equipslots. Tested successfully with some basic scenarios:

- 1 stack in itemslots will refill the equip slot, remainder will be put in itemslots
- 3 incomplete stacks in itemslots will fill up the equipped stack and leave remainder in itemslot
- the equip slot fully consumes 1 stack in itemslots
- the equip slot fully consumes multiple stacks in itemslots


