### PR TITLE
Fix crash when pressing toggle key in the character select screen.

### DIFF
--- a/modinfo.lua
+++ b/modinfo.lua
@@ -1,7 +1,7 @@
 name        = "DJPaul's Sort Inventory"
 description = "Automatically stacks and sorts your inventory into a sensible order."
 author      = "Paul Gibbs (DJPaul)"
-version     = "1.8"
+version     = "1.9"
 forumthread = "/topic/54138-new-mod-djpauls-sort-inventory/"
 
 api_version                = 10  -- DST api version

--- a/modmain.lua
+++ b/modmain.lua
@@ -371,7 +371,10 @@ end)
 
 --- Press "G" to sort your inventory.
 GLOBAL.TheInput:AddKeyDownHandler(GetModConfigData("keybind"), function()
-	if GLOBAL.ThePlayer.HUD:IsConsoleScreenOpen() or GLOBAL.ThePlayer.HUD:IsChatInputScreenOpen() then
+	if not (GLOBAL.TheFrontEnd:GetActiveScreen() and
+			GLOBAL.TheFrontEnd:GetActiveScreen().name and
+			type(GLOBAL.TheFrontEnd:GetActiveScreen().name) == "string" and
+			GLOBAL.TheFrontEnd:GetActiveScreen().name == "HUD") then
 		return
 	end
 


### PR DESCRIPTION
HUD check condition copied from "Fix for Too Many Items" (workshop-881455419) v1.0.4.6.
Version also bumped.
	modified:   modinfo.lua
	modified:   modmain.lua